### PR TITLE
Quark Crate Recipe

### DIFF
--- a/kubejs/server_scripts/mods/quark/shaped.js
+++ b/kubejs/server_scripts/mods/quark/shaped.js
@@ -1,0 +1,4 @@
+ServerEvents.recipes(e => {
+    e.shaped('quark:crate', ['IPI', 'PCP', 'IPI'], { I: 'minecraft:iron_ingot', P: '#minecraft:planks', C: '#forge:chests/wooden' })
+        .id(`kubejs:quark/shaped/crate`)
+})


### PR DESCRIPTION
It normally only loads the recipe if oddities is enabled.

**Describe the PR**
It adds the recipe for the quark crate

**Screenshots**
<img width="285" height="150" alt="image" src="https://github.com/user-attachments/assets/bbb2f056-8682-48ec-be7c-614df16c44ce" />


**Additional context**
None
